### PR TITLE
소켓 모드 클라이언트 추가 및 HTTP 클라이언트 타임아웃 설정

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ $ go get -u github.com/dooray-go/dooray
 
 | Category | Feature | Method | Description |
 |----------|---------|--------|-------------|
+| **[Socket Mode](socketmode/README.md)** | Agent | `NewAgent` | Real-time event handling via WebSocket |
 | **Messenger** | Webhook | `PostWebhook` | Send messages via webhook |
 | | Direct Send | `DirectSend` | Send direct messages to users |
+| | Send Message | `SendMessage` | Send messages to a channel |
 | **Project** | Get Projects | `GetProjects` | Retrieve list of projects |
 | | Get Posts | `GetPosts` | Retrieve posts from a project |
 | | Get Posts (Options) | `GetPostsWithOptions` | Retrieve posts with full query parameters (paging, filters, date, sort) |

--- a/example/socketmode/echo-bot/main.go
+++ b/example/socketmode/echo-bot/main.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/dooray-go/dooray/socketmode"
+)
+
+func main() {
+	token := os.Getenv("DOORAY_AGENT_TOKEN")
+	if token == "" {
+		log.Fatal("DOORAY_AGENT_TOKEN is required")
+	}
+
+	opts := []socketmode.Option{}
+
+	if domain := os.Getenv("DOORAY_DOMAIN"); domain != "" {
+		opts = append(opts, socketmode.WithDomain(domain))
+	}
+	if baseURL := os.Getenv("DOORAY_BASE_URL"); baseURL != "" {
+		opts = append(opts, socketmode.WithBaseURL(baseURL))
+	}
+
+	agent := socketmode.NewAgent(token, opts...)
+
+	// Handle messenger events
+	agent.OnMessenger(func(req *socketmode.SocketModeRequest) {
+		// Ignore bot messages to avoid infinite echo loops
+		if req.IsBotMessage() {
+			return
+		}
+
+		text := req.Text()
+		if text == "" {
+			return
+		}
+		fmt.Printf("Message from %s in channel %s: %s\n", req.SenderID(), req.ChannelID(), text)
+
+		if err := req.Reply(fmt.Sprintf("Echo: %s", text)); err != nil {
+			log.Printf("reply failed: %v", err)
+		}
+	})
+
+	// Handle task events
+	agent.OnTask(func(req *socketmode.SocketModeRequest) {
+		fmt.Printf("Task event: type=%s action=%s\n", req.Type, req.Action)
+	})
+
+	// Handle specific event with On()
+	agent.On("messenger", "message", "create", func(req *socketmode.SocketModeRequest) {
+		fmt.Printf("New message created: %s\n", req.Text())
+	})
+
+	log.Println("Starting echo bot...")
+	if err := agent.Run(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/dooray-go/dooray
 
 go 1.22.1
+
+require github.com/gorilla/websocket v1.5.3

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/hook/web_hook.go
+++ b/hook/web_hook.go
@@ -24,12 +24,14 @@ type Attachment struct {
 	Color     string `json:"color"`
 }
 
+var defaultHTTPClient = utils.NewDefaultHTTPClient()
+
 func PostWebhook(url string, msg *WebhookMessage) error {
-	return PostWebhookCustomHTTPContext(context.Background(), url, http.DefaultClient, msg)
+	return PostWebhookCustomHTTPContext(context.Background(), url, defaultHTTPClient, msg)
 }
 
 func PostWebhookContext(ctx context.Context, url string, msg *WebhookMessage) error {
-	return PostWebhookCustomHTTPContext(ctx, url, http.DefaultClient, msg)
+	return PostWebhookCustomHTTPContext(ctx, url, defaultHTTPClient, msg)
 }
 
 func PostWebhookCustomHTTP(url string, httpClient *http.Client, msg *WebhookMessage) error {

--- a/openapi/account/account.go
+++ b/openapi/account/account.go
@@ -1,31 +1,31 @@
-package project
+package account
 
 import (
 	"github.com/dooray-go/dooray/utils"
 	"net/http"
 )
 
-type Project struct {
+type Account struct {
 	endPoint   string
 	httpClient *http.Client
 }
 
-func NewDefaultProject() *Project {
-	return &Project{
+func NewDefaultAccount() *Account {
+	return &Account{
 		endPoint:   "https://api.dooray.com",
 		httpClient: utils.NewDefaultHTTPClient(),
 	}
 }
 
-func NewProject(endPoint string) *Project {
-	return &Project{
+func NewAccount(endPoint string) *Account {
+	return &Account{
 		endPoint:   endPoint,
 		httpClient: utils.NewDefaultHTTPClient(),
 	}
 }
 
-func NewProjectWithClient(endPoint string, httpClient *http.Client) *Project {
-	return &Project{
+func NewAccountWithClient(endPoint string, httpClient *http.Client) *Account {
+	return &Account{
 		endPoint:   endPoint,
 		httpClient: httpClient,
 	}

--- a/openapi/account/getmember.go
+++ b/openapi/account/getmember.go
@@ -11,11 +11,11 @@ import (
 )
 
 func (a *Account) GetMember(apikey string, id string) (*model.GetMemberResponse, error) { // 반환 타입 수정
-	return a.GetMemberCustomHTTPContext(context.Background(), apikey, http.DefaultClient, id)
+	return a.GetMemberCustomHTTPContext(context.Background(), apikey, a.httpClient, id)
 }
 
 func (a *Account) GetMemberContext(ctx context.Context, apikey string, id string) (*model.GetMemberResponse, error) { // 반환 타입 수정
-	return a.GetMemberCustomHTTPContext(ctx, apikey, http.DefaultClient, id)
+	return a.GetMemberCustomHTTPContext(ctx, apikey, a.httpClient, id)
 }
 
 func (a *Account) GetMemberCustomHTTP(apikey string, httpClient *http.Client, id string) (*model.GetMemberResponse, error) { // 반환 타입 수정

--- a/openapi/account/getmembers.go
+++ b/openapi/account/getmembers.go
@@ -11,28 +11,12 @@ import (
 	model "github.com/dooray-go/dooray/openapi/model/account"
 )
 
-type Account struct {
-	endPoint string
-}
-
-func NewDefaultAccount() *Account {
-	return &Account{
-		endPoint: "https://api.dooray.com",
-	}
-}
-
-func NewAccount(endPoint string) *Account {
-	return &Account{
-		endPoint: endPoint,
-	}
-}
-
 func (a *Account) GetMembers(apikey string, name string, userCode string) (*model.GetMembersResponse, error) {
-	return a.GetMembersCustomHTTPContext(context.Background(), apikey, http.DefaultClient, name, userCode)
+	return a.GetMembersCustomHTTPContext(context.Background(), apikey, a.httpClient, name, userCode)
 }
 
 func (a *Account) GetMembersContext(ctx context.Context, apikey string, name string, userCode string) (*model.GetMembersResponse, error) {
-	return a.GetMembersCustomHTTPContext(ctx, apikey, http.DefaultClient, name, userCode)
+	return a.GetMembersCustomHTTPContext(ctx, apikey, a.httpClient, name, userCode)
 }
 
 func (a *Account) GetMembersCustomHTTP(apikey string, httpClient *http.Client, name string, userCode string) (*model.GetMembersResponse, error) {

--- a/openapi/calendar/calendar.go
+++ b/openapi/calendar/calendar.go
@@ -1,16 +1,32 @@
 package calendar
 
+import (
+	"github.com/dooray-go/dooray/utils"
+	"net/http"
+)
+
 type Calendar struct {
-	endPoint string
+	endPoint   string
+	httpClient *http.Client
 }
 
 func NewDefaultCalendar() *Calendar {
 	return &Calendar{
-		endPoint: "https://api.dooray.com",
+		endPoint:   "https://api.dooray.com",
+		httpClient: utils.NewDefaultHTTPClient(),
 	}
 }
+
 func NewCalendar(endPoint string) *Calendar {
 	return &Calendar{
-		endPoint: endPoint,
+		endPoint:   endPoint,
+		httpClient: utils.NewDefaultHTTPClient(),
+	}
+}
+
+func NewCalendarWithClient(endPoint string, httpClient *http.Client) *Calendar {
+	return &Calendar{
+		endPoint:   endPoint,
+		httpClient: httpClient,
 	}
 }

--- a/openapi/calendar/getcalendars.go
+++ b/openapi/calendar/getcalendars.go
@@ -10,10 +10,10 @@ import (
 )
 
 func (c *Calendar) GetCalendars(apikey string) (*model.GetCalendarsResponse, error) {
-	return c.GetCalendarsCustomHTTPContext(context.Background(), apikey, http.DefaultClient)
+	return c.GetCalendarsCustomHTTPContext(context.Background(), apikey, c.httpClient)
 }
 func (c *Calendar) GetCalendarsContext(ctx context.Context, apikey string) (*model.GetCalendarsResponse, error) {
-	return c.GetCalendarsCustomHTTPContext(ctx, apikey, http.DefaultClient)
+	return c.GetCalendarsCustomHTTPContext(ctx, apikey, c.httpClient)
 }
 func (c *Calendar) GetCalendarsCustomHTTP(apikey string, httpClient *http.Client) (*model.GetCalendarsResponse, error) {
 	return c.GetCalendarsCustomHTTPContext(context.Background(), apikey, httpClient)

--- a/openapi/calendar/getevents.go
+++ b/openapi/calendar/getevents.go
@@ -13,10 +13,10 @@ import (
 )
 
 func (c *Calendar) GetEvents(apikey string, calendars string, timeMin time.Time, timeMax time.Time) (*model.EventsResponse, error) {
-	return c.GetEventsCustomHTTPContext(context.Background(), apikey, http.DefaultClient, calendars, timeMin, timeMax)
+	return c.GetEventsCustomHTTPContext(context.Background(), apikey, c.httpClient, calendars, timeMin, timeMax)
 }
 func (c *Calendar) GetEventsContext(ctx context.Context, apikey string, calendars string, timeMin time.Time, timeMax time.Time) (*model.EventsResponse, error) {
-	return c.GetEventsCustomHTTPContext(ctx, apikey, http.DefaultClient, calendars, timeMin, timeMax)
+	return c.GetEventsCustomHTTPContext(ctx, apikey, c.httpClient, calendars, timeMin, timeMax)
 }
 func (c *Calendar) GetEventsCustomHTTP(apikey string, httpClient *http.Client, calendars string, timeMin time.Time, timeMax time.Time) (*model.EventsResponse, error) {
 	return c.GetEventsCustomHTTPContext(context.Background(), apikey, httpClient, calendars, timeMin, timeMax)

--- a/openapi/calendar/postevents.go
+++ b/openapi/calendar/postevents.go
@@ -12,10 +12,10 @@ import (
 )
 
 func (c *Calendar) CreateEvent(apikey string, calendarID string, event model.EventRequest) (*model.EventResponse, error) {
-	return c.CreateEventCustomHTTPContext(context.Background(), apikey, http.DefaultClient, calendarID, event)
+	return c.CreateEventCustomHTTPContext(context.Background(), apikey, c.httpClient, calendarID, event)
 }
 func (c *Calendar) CreateEventContext(ctx context.Context, apikey string, calendarID string, event model.EventRequest) (*model.EventResponse, error) {
-	return c.CreateEventCustomHTTPContext(ctx, apikey, http.DefaultClient, calendarID, event)
+	return c.CreateEventCustomHTTPContext(ctx, apikey, c.httpClient, calendarID, event)
 }
 func (c *Calendar) CreateEventCustomHTTP(apikey string, httpClient *http.Client, calendarID string, event model.EventRequest) (*model.EventResponse, error) {
 	return c.CreateEventCustomHTTPContext(context.Background(), apikey, httpClient, calendarID, event)

--- a/openapi/calendar/postevents_test.go
+++ b/openapi/calendar/postevents_test.go
@@ -48,7 +48,7 @@ func TestCreateEvent(t *testing.T) {
 	defer mockServer.Close()
 
 	// Create a Calendar instance with the mock server endpoint
-	calendar := &Calendar{endPoint: mockServer.URL}
+	calendar := NewCalendar(mockServer.URL)
 
 	// Create a sample EventRequest
 	event := model.EventRequest{

--- a/openapi/messenger/directsend.go
+++ b/openapi/messenger/directsend.go
@@ -11,33 +11,17 @@ import (
 	"net/http"
 )
 
-type Messenger struct {
-	endPoint string
-}
-
-func NewDefaultMessenger() *Messenger {
-	return &Messenger{
-		endPoint: "https://api.dooray.com",
-	}
-}
-
-func NewMessenger(endPoint string) *Messenger {
-	return &Messenger{
-		endPoint: endPoint,
-	}
-}
-
 type DirectSendRequest struct {
 	Text                 string `json:"text"`
 	OrganizationMemberId string `json:"organizationMemberId"`
 }
 
 func (m Messenger) DirectSend(apikey string, msg *DirectSendRequest) (*model.DirectSendResponse, error) {
-	return m.DirectSendCustomHTTPContext(context.Background(), apikey, http.DefaultClient, msg)
+	return m.DirectSendCustomHTTPContext(context.Background(), apikey, m.httpClient, msg)
 }
 
 func (m Messenger) DirectSendContext(ctx context.Context, apikey string, msg *DirectSendRequest) (*model.DirectSendResponse, error) {
-	return m.DirectSendCustomHTTPContext(ctx, apikey, http.DefaultClient, msg)
+	return m.DirectSendCustomHTTPContext(ctx, apikey, m.httpClient, msg)
 }
 
 func (m Messenger) DirectSendCustomHTTP(apikey string, httpClient *http.Client, msg *DirectSendRequest) (*model.DirectSendResponse, error) {

--- a/openapi/messenger/messenger.go
+++ b/openapi/messenger/messenger.go
@@ -1,31 +1,31 @@
-package project
+package messenger
 
 import (
 	"github.com/dooray-go/dooray/utils"
 	"net/http"
 )
 
-type Project struct {
+type Messenger struct {
 	endPoint   string
 	httpClient *http.Client
 }
 
-func NewDefaultProject() *Project {
-	return &Project{
+func NewDefaultMessenger() *Messenger {
+	return &Messenger{
 		endPoint:   "https://api.dooray.com",
 		httpClient: utils.NewDefaultHTTPClient(),
 	}
 }
 
-func NewProject(endPoint string) *Project {
-	return &Project{
+func NewMessenger(endPoint string) *Messenger {
+	return &Messenger{
 		endPoint:   endPoint,
 		httpClient: utils.NewDefaultHTTPClient(),
 	}
 }
 
-func NewProjectWithClient(endPoint string, httpClient *http.Client) *Project {
-	return &Project{
+func NewMessengerWithClient(endPoint string, httpClient *http.Client) *Messenger {
+	return &Messenger{
 		endPoint:   endPoint,
 		httpClient: httpClient,
 	}

--- a/openapi/messenger/sendmessage.go
+++ b/openapi/messenger/sendmessage.go
@@ -1,0 +1,68 @@
+package messenger
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	model "github.com/dooray-go/dooray/openapi/model/messenger"
+	"io"
+	"net/http"
+)
+
+type SendMessageRequest struct {
+	Text string `json:"text"`
+}
+
+func (m Messenger) SendMessage(apikey string, channelID string, msg *SendMessageRequest) (*model.SendMessageResponse, error) {
+	return m.SendMessageCustomHTTPContext(context.Background(), apikey, channelID, m.httpClient, msg)
+}
+
+func (m Messenger) SendMessageContext(ctx context.Context, apikey string, channelID string, msg *SendMessageRequest) (*model.SendMessageResponse, error) {
+	return m.SendMessageCustomHTTPContext(ctx, apikey, channelID, m.httpClient, msg)
+}
+
+func (m Messenger) SendMessageCustomHTTP(apikey string, channelID string, httpClient *http.Client, msg *SendMessageRequest) (*model.SendMessageResponse, error) {
+	return m.SendMessageCustomHTTPContext(context.Background(), apikey, channelID, httpClient, msg)
+}
+
+func (m Messenger) SendMessageCustomHTTPContext(ctx context.Context, apikey string, channelID string, httpClient *http.Client, msg *SendMessageRequest) (*model.SendMessageResponse, error) {
+	raw, err := json.Marshal(msg)
+	if err != nil {
+		return nil, fmt.Errorf("marshal failed: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/messenger/v1/channels/%s/logs", m.endPoint, channelID)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(raw))
+	if err != nil {
+		return nil, fmt.Errorf("failed new request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("dooray-api %s", apikey))
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send message: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if err := checkStatusCode(resp); err != nil {
+		return nil, err
+	}
+
+	resBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var response model.SendMessageResponse
+	if err := json.Unmarshal(resBody, &response); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	response.RawJSON = string(resBody)
+
+	return &response, nil
+}
+

--- a/openapi/model/messenger/sendmessage_response.go
+++ b/openapi/model/messenger/sendmessage_response.go
@@ -1,0 +1,13 @@
+package messenger
+
+import "github.com/dooray-go/dooray/openapi/model"
+
+type SendMessageResult struct {
+	ID string `json:"id"`
+}
+
+type SendMessageResponse struct {
+	Header  model.ResponseHeader `json:"header"`
+	Result  SendMessageResult    `json:"result"`
+	RawJSON string               `json:"-"`
+}

--- a/openapi/project/getposts.go
+++ b/openapi/project/getposts.go
@@ -45,7 +45,7 @@ func (c *Project) GetPosts(apikey string, projectId string, toMemberIds string, 
 		ToMemberIds:         toMemberIds,
 		PostWorkflowClasses: postWorkflowClasses,
 	}
-	return c.GetPostsWithOptionsCustomHTTPContext(context.Background(), apikey, http.DefaultClient, projectId, opts)
+	return c.GetPostsWithOptionsCustomHTTPContext(context.Background(), apikey, c.httpClient, projectId, opts)
 }
 
 func (c *Project) GetPostsContext(ctx context.Context, apikey string, projectId string, toMemberIds string, postWorkflowClasses string) (*model.GetPostsResponse, error) {
@@ -53,7 +53,7 @@ func (c *Project) GetPostsContext(ctx context.Context, apikey string, projectId 
 		ToMemberIds:         toMemberIds,
 		PostWorkflowClasses: postWorkflowClasses,
 	}
-	return c.GetPostsWithOptionsCustomHTTPContext(ctx, apikey, http.DefaultClient, projectId, opts)
+	return c.GetPostsWithOptionsCustomHTTPContext(ctx, apikey, c.httpClient, projectId, opts)
 }
 
 func (c *Project) GetPostsCustomHTTP(apikey string, httpClient *http.Client, projectId string, toMemberIds string, postWorkflowClasses string) (*model.GetPostsResponse, error) {
@@ -74,11 +74,11 @@ func (c *Project) GetPostsCustomHTTPContext(ctx context.Context, apikey string, 
 
 // GetPostsWithOptions retrieves posts with full query parameter support.
 func (c *Project) GetPostsWithOptions(apikey string, projectId string, opts GetPostsOptions) (*model.GetPostsResponse, error) {
-	return c.GetPostsWithOptionsCustomHTTPContext(context.Background(), apikey, http.DefaultClient, projectId, opts)
+	return c.GetPostsWithOptionsCustomHTTPContext(context.Background(), apikey, c.httpClient, projectId, opts)
 }
 
 func (c *Project) GetPostsWithOptionsContext(ctx context.Context, apikey string, projectId string, opts GetPostsOptions) (*model.GetPostsResponse, error) {
-	return c.GetPostsWithOptionsCustomHTTPContext(ctx, apikey, http.DefaultClient, projectId, opts)
+	return c.GetPostsWithOptionsCustomHTTPContext(ctx, apikey, c.httpClient, projectId, opts)
 }
 
 func (c *Project) GetPostsWithOptionsCustomHTTP(apikey string, httpClient *http.Client, projectId string, opts GetPostsOptions) (*model.GetPostsResponse, error) {

--- a/openapi/project/getprojects.go
+++ b/openapi/project/getprojects.go
@@ -10,11 +10,11 @@ import (
 )
 
 func (c *Project) GetProjects(apikey string, projectType string, scope string, state string) (*model.GetProjectsResponse, error) {
-	return c.GetProjectsCustomHTTPContext(context.Background(), apikey, http.DefaultClient, projectType, scope, state)
+	return c.GetProjectsCustomHTTPContext(context.Background(), apikey, c.httpClient, projectType, scope, state)
 }
 
 func (c *Project) GetProjectsContext(ctx context.Context, apikey string, projectType string, scope string, state string) (*model.GetProjectsResponse, error) {
-	return c.GetProjectsCustomHTTPContext(ctx, apikey, http.DefaultClient, projectType, scope, state)
+	return c.GetProjectsCustomHTTPContext(ctx, apikey, c.httpClient, projectType, scope, state)
 }
 
 func (c *Project) GetProjectsCustomHTTP(apikey string, httpClient *http.Client, projectType string, scope string, state string) (*model.GetProjectsResponse, error) {

--- a/openapi/project/postposts.go
+++ b/openapi/project/postposts.go
@@ -12,11 +12,11 @@ import (
 )
 
 func (c *Project) CreatePost(apikey string, projectID string, post model.PostRequest) (*model.PostResponse, error) {
-	return c.CreatePostCustomHTTPContext(context.Background(), apikey, http.DefaultClient, projectID, post)
+	return c.CreatePostCustomHTTPContext(context.Background(), apikey, c.httpClient, projectID, post)
 }
 
 func (c *Project) CreatePostContext(ctx context.Context, apikey string, projectID string, post model.PostRequest) (*model.PostResponse, error) {
-	return c.CreatePostCustomHTTPContext(ctx, apikey, http.DefaultClient, projectID, post)
+	return c.CreatePostCustomHTTPContext(ctx, apikey, c.httpClient, projectID, post)
 }
 
 func (c *Project) CreatePostCustomHTTP(apikey string, httpClient *http.Client, projectID string, post model.PostRequest) (*model.PostResponse, error) {

--- a/socketmode/README.md
+++ b/socketmode/README.md
@@ -1,0 +1,186 @@
+# Socket Mode
+
+Socket Mode allows your bot to receive real-time events from Dooray via a persistent WebSocket connection, without setting up a public webhook endpoint.
+
+## Prerequisites
+
+- **Agent Token**: `DOORAY_AGENT_TOKEN` environment variable (issued from Dooray agent settings)
+- **Domain** (optional): `DOORAY_DOMAIN` environment variable (e.g. `company`)
+
+## Quick Start
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+    "os"
+
+    "github.com/dooray-go/dooray/socketmode"
+)
+
+func main() {
+    agent := socketmode.NewAgent(os.Getenv("DOORAY_AGENT_TOKEN"),
+        socketmode.WithDomain(os.Getenv("DOORAY_DOMAIN")),
+    )
+
+    agent.OnMessenger(func(req *socketmode.SocketModeRequest) {
+        if text := req.Text(); text != "" {
+            req.Reply("Echo: " + text)
+        }
+    })
+
+    if err := agent.Run(); err != nil {
+        log.Fatal(err)
+    }
+}
+```
+
+## Agent Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `WithBaseURL(url)` | Dooray API base URL | `https://api.dooray.com` |
+| `WithDomain(domain)` | Dooray domain name | (empty) |
+| `WithHTTPClient(client)` | Custom `*http.Client` for REST API calls | `http.DefaultClient` |
+| `WithLogger(logger)` | Custom `*log.Logger` | stdout with `[dooray-socketmode]` prefix |
+| `WithPingInterval(d)` | WebSocket ping interval | `30s` |
+| `WithReconnectBackoff(min, max)` | Reconnect backoff range | `1s` ~ `30s` |
+
+```go
+agent := socketmode.NewAgent(token,
+    socketmode.WithBaseURL("https://api.dooray.com"),
+    socketmode.WithDomain("mycompany"),
+    socketmode.WithPingInterval(20*time.Second),
+    socketmode.WithReconnectBackoff(2*time.Second, 60*time.Second),
+)
+```
+
+## Event Handlers
+
+### Service-specific handlers
+
+Register handlers for a specific Dooray service. Each handler receives all events from that service.
+
+```go
+// Messenger events (messages, reactions, etc.)
+agent.OnMessenger(func(req *socketmode.SocketModeRequest) {
+    fmt.Printf("Messenger event: type=%s action=%s\n", req.Type, req.Action)
+})
+
+// Task events (create, update, status change, etc.)
+agent.OnTask(func(req *socketmode.SocketModeRequest) {
+    fmt.Printf("Task event: type=%s action=%s\n", req.Type, req.Action)
+})
+
+// Wiki events (page create, update, etc.)
+agent.OnWiki(func(req *socketmode.SocketModeRequest) {
+    fmt.Printf("Wiki event: type=%s action=%s\n", req.Type, req.Action)
+})
+```
+
+### Filtered handler with `On()`
+
+Register a handler with fine-grained filtering. Empty string matches all values for that field.
+
+```go
+// Only handle new message creation in messenger
+agent.On("messenger", "message", "create", func(req *socketmode.SocketModeRequest) {
+    fmt.Printf("New message: %s\n", req.Text())
+})
+
+// Handle all task events regardless of type and action
+agent.On("task", "", "", func(req *socketmode.SocketModeRequest) {
+    fmt.Println("Something happened in task service")
+})
+
+// Handle all "create" actions across all services
+agent.On("", "", "create", func(req *socketmode.SocketModeRequest) {
+    fmt.Printf("Something was created in %s\n", req.Service)
+})
+```
+
+## SocketModeRequest
+
+| Method | Return | Description |
+|--------|--------|-------------|
+| `Text()` | `string` | Message text from entity data |
+| `ChannelID()` | `string` | Channel ID from entity data |
+| `SenderID()` | `string` | Sender member ID from entity data |
+| `IsMessage()` | `bool` | True if messenger message event |
+| `IsType(t)` | `bool` | Check event type |
+| `IsAction(a)` | `bool` | Check event action |
+| `IsService(s)` | `bool` | Check event service |
+| `Reply(text)` | `error` | Send a reply to the originating channel |
+
+### Fields
+
+```go
+type SocketModeRequest struct {
+    EnvelopeID string              // Unique message identifier
+    Type       string              // Event type (e.g. "message")
+    Service    string              // Service name ("messenger", "task", "wiki")
+    Action     string              // Action type ("create", "update", "delete")
+    Payload    map[string]any      // Raw event payload
+    Entity     *Entity             // Event entity (type + data)
+    Actor      *Actor              // Who triggered the event (type + data)
+    ActionData *DataWrapper        // Additional action details
+}
+```
+
+### Entity data for messenger events
+
+```go
+agent.OnMessenger(func(req *socketmode.SocketModeRequest) {
+    if req.Entity != nil {
+        data := req.Entity.Data
+        fmt.Println("id:", data["id"])
+        fmt.Println("channelId:", data["channelId"])
+        fmt.Println("senderId:", data["senderId"])
+        fmt.Println("text:", data["text"])
+        fmt.Println("sentAt:", data["sentAt"])
+    }
+})
+```
+
+## Using the Messenger Client
+
+The agent exposes the underlying `openapi/messenger.Messenger` client for direct REST API calls.
+
+```go
+agent := socketmode.NewAgent(token)
+m := agent.Messenger()
+
+// Send a message to a channel
+m.SendMessage(token, "channel-id", &messenger.SendMessageRequest{
+    Text: "Hello from bot!",
+})
+
+// Send a direct message to a user
+m.DirectSend(token, &messenger.DirectSendRequest{
+    Text:                 "Hello!",
+    OrganizationMemberId: "member-id",
+})
+```
+
+## Graceful Shutdown
+
+`Run()` handles `SIGINT` and `SIGTERM` automatically. Use `RunContext()` for custom context control.
+
+```go
+ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+defer cancel()
+
+if err := agent.RunContext(ctx); err != nil {
+    log.Fatal(err)
+}
+```
+
+## Connection Lifecycle
+
+1. `POST /agent/v1/websocket/connect` to obtain a WebSocket URL
+2. Connect via WebSocket with `dooray-api` authorization header
+3. Receive events and auto-acknowledge with `envelope_id`
+4. Ping/pong keeps the connection alive
+5. On disconnect, reconnect with exponential backoff (jitter included)

--- a/socketmode/agent.go
+++ b/socketmode/agent.go
@@ -1,0 +1,415 @@
+package socketmode
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"math/rand/v2"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/dooray-go/dooray/openapi/messenger"
+	"github.com/dooray-go/dooray/utils"
+	"github.com/gorilla/websocket"
+)
+
+// HandlerFunc is the function signature for event handlers.
+type HandlerFunc func(req *SocketModeRequest)
+
+// Agent manages a WebSocket connection to Dooray and dispatches events to handlers.
+type Agent struct {
+	agentToken string
+	baseURL    string
+	domain     string
+
+	httpClient *http.Client
+	messenger  *messenger.Messenger
+	logger     *log.Logger
+	memberID   string // bot's own organizationMemberId, set after token fetch
+	pingInterval  time.Duration
+	pingTimeout   time.Duration
+	reconnectMin  time.Duration
+	reconnectMax  time.Duration
+
+	mu               sync.RWMutex
+	messengerHandler HandlerFunc
+	taskHandler      HandlerFunc
+	wikiHandler      HandlerFunc
+	genericHandlers  []genericHandler
+}
+
+type genericHandler struct {
+	service string
+	typ     string
+	action  string
+	fn      HandlerFunc
+}
+
+// NewAgent creates a new socket mode Agent.
+// The agentToken is the DOORAY_AGENT_TOKEN used for authentication.
+func NewAgent(agentToken string, opts ...Option) *Agent {
+	a := &Agent{
+		agentToken:   agentToken,
+		baseURL:      defaultBaseURL,
+		httpClient:   utils.NewDefaultHTTPClient(),
+		logger:       log.New(os.Stdout, "[dooray-socketmode] ", log.LstdFlags),
+		pingInterval: defaultPingInterval,
+		pingTimeout:  defaultPingTimeout,
+		reconnectMin: defaultReconnectMin,
+		reconnectMax: defaultReconnectMax,
+	}
+	for _, opt := range opts {
+		opt(a)
+	}
+	a.messenger = messenger.NewMessengerWithClient(a.baseURL, a.httpClient)
+	return a
+}
+
+// Messenger returns the underlying Messenger client for making REST API calls.
+func (a *Agent) Messenger() *messenger.Messenger {
+	return a.messenger
+}
+
+// OnMessenger registers a handler for all messenger service events.
+func (a *Agent) OnMessenger(fn HandlerFunc) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.messengerHandler = fn
+}
+
+// OnTask registers a handler for all task service events.
+func (a *Agent) OnTask(fn HandlerFunc) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.taskHandler = fn
+}
+
+// OnWiki registers a handler for all wiki service events.
+func (a *Agent) OnWiki(fn HandlerFunc) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.wikiHandler = fn
+}
+
+// On registers a handler with optional filtering by service, type, and action.
+// Empty strings match all values for that field.
+func (a *Agent) On(service, typ, action string, fn HandlerFunc) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.genericHandlers = append(a.genericHandlers, genericHandler{
+		service: service,
+		typ:     typ,
+		action:  action,
+		fn:      fn,
+	})
+}
+
+// Run starts the WebSocket connection and blocks until the context is cancelled
+// or a termination signal is received.
+func (a *Agent) Run() error {
+	return a.RunContext(context.Background())
+}
+
+// RunContext starts the WebSocket connection with the given context.
+func (a *Agent) RunContext(ctx context.Context) error {
+	if a.agentToken == "" {
+		return ErrNoToken
+	}
+	if a.domain == "" {
+		return ErrNoDomain
+	}
+
+	ctx, cancel := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	backoff := a.reconnectMin
+
+	for {
+		err := a.connectAndListen(ctx)
+		if ctx.Err() != nil {
+			a.logger.Println("shutting down")
+			return nil
+		}
+
+		a.logger.Printf("connection lost: %v, reconnecting in %s", err, backoff)
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(backoff):
+		}
+
+		// exponential backoff with jitter
+		backoff = time.Duration(float64(backoff) * (1.5 + rand.Float64()*0.5))
+		if backoff > a.reconnectMax {
+			backoff = a.reconnectMax
+		}
+	}
+}
+
+// socketModeToken holds credentials obtained from the token endpoint.
+type socketModeToken struct {
+	AccessToken          string `json:"accessToken"`
+	TenantID             string `json:"tenantId"`
+	OrganizationMemberID string `json:"organizationMemberId"`
+}
+
+func (a *Agent) connectAndListen(ctx context.Context) error {
+	// Step 1: fetch socket mode token
+	token, err := a.fetchSocketModeToken(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to fetch socket mode token: %w", err)
+	}
+
+	a.memberID = token.OrganizationMemberID
+
+	// Step 2: build WebSocket URL from domain + token info
+	wsURL := a.buildWebSocketURL(token)
+	a.logger.Printf("connecting to %s", wsURL)
+
+	dialer := websocket.Dialer{
+		HandshakeTimeout: 10 * time.Second,
+	}
+
+	header := http.Header{}
+	header.Set("Authorization", fmt.Sprintf("Bearer %s", token.AccessToken))
+
+	conn, _, err := dialer.DialContext(ctx, wsURL, header)
+	if err != nil {
+		return fmt.Errorf("websocket dial failed: %w", err)
+	}
+	defer conn.Close()
+
+	a.logger.Println("connected")
+
+	done := make(chan struct{})
+	defer close(done)
+
+	// ping loop
+	go func() {
+		ticker := time.NewTicker(a.pingInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				if err := conn.WriteControl(
+					websocket.PingMessage, nil,
+					time.Now().Add(a.pingTimeout),
+				); err != nil {
+					a.logger.Printf("ping failed: %v", err)
+					return
+				}
+			case <-done:
+				return
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			closeMsg := websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")
+			conn.WriteMessage(websocket.CloseMessage, closeMsg)
+			return ctx.Err()
+		default:
+		}
+
+		conn.SetReadDeadline(time.Now().Add(a.pingInterval + a.pingTimeout))
+
+		_, message, err := conn.ReadMessage()
+		if err != nil {
+			return fmt.Errorf("read failed: %w", err)
+		}
+
+		a.logger.Printf("recv: %s", string(message))
+
+		var raw map[string]interface{}
+		if err := json.Unmarshal(message, &raw); err != nil {
+			a.logger.Printf("failed to unmarshal event: %v", err)
+			continue
+		}
+
+		// skip sessionInfo messages
+		if msgType, _ := raw["type"].(string); msgType == "sessionInfo" {
+			a.logger.Printf("session established")
+			continue
+		}
+
+		req := a.parseRawMessage(raw)
+		if req == nil {
+			continue
+		}
+
+		// send ack if envelope_id is present
+		if req.EnvelopeID != "" {
+			ack := map[string]string{"envelope_id": req.EnvelopeID}
+			if ackData, err := json.Marshal(ack); err == nil {
+				conn.WriteMessage(websocket.TextMessage, ackData)
+			}
+		}
+
+		req.agent = a
+		go a.dispatch(req)
+	}
+}
+
+// fetchSocketModeToken calls POST /common/v1/socket-mode/tokens to obtain
+// accessToken, tenantId, and organizationMemberId for WebSocket connection.
+func (a *Agent) fetchSocketModeToken(ctx context.Context) (*socketModeToken, error) {
+	url := a.baseURL + "/common/v1/socket-mode/tokens"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("dooray-api %s", a.agentToken))
+
+	resp, err := a.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("token endpoint returned %s", resp.Status)
+	}
+
+	var result struct {
+		Header struct {
+			IsSuccessful  bool   `json:"isSuccessful"`
+			ResultCode    int    `json:"resultCode"`
+			ResultMessage string `json:"resultMessage"`
+		} `json:"header"`
+		Result socketModeToken `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode token response: %w", err)
+	}
+	if !result.Header.IsSuccessful {
+		return nil, fmt.Errorf("token request failed: %s", result.Header.ResultMessage)
+	}
+	if result.Result.AccessToken == "" || result.Result.TenantID == "" || result.Result.OrganizationMemberID == "" {
+		return nil, fmt.Errorf("incomplete token response: missing required fields")
+	}
+
+	return &result.Result, nil
+}
+
+// buildWebSocketURL constructs wss://{domain}/messenger/v5/ws/{tenantId}/{memberId}.
+func (a *Agent) buildWebSocketURL(token *socketModeToken) string {
+	host := a.domain
+	// strip protocol if present
+	host = strings.TrimPrefix(host, "https://")
+	host = strings.TrimPrefix(host, "http://")
+	// strip trailing slash
+	host = strings.TrimRight(host, "/")
+
+	return fmt.Sprintf("wss://%s/messenger/v5/ws/%s/%s", host, token.TenantID, token.OrganizationMemberID)
+}
+
+// parseRawMessage converts raw WebSocket JSON into a SocketModeRequest.
+// Returns nil if the message should be filtered out (e.g. system messages).
+func (a *Agent) parseRawMessage(raw map[string]interface{}) *SocketModeRequest {
+	msgType, _ := raw["type"].(string)
+	action, _ := raw["action"].(string)
+
+	// only pass channelLog with create/update actions to handlers
+	if msgType == "channelLog" && action != "create" && action != "update" {
+		return nil
+	}
+
+	content, _ := raw["content"].(map[string]interface{})
+	if content == nil {
+		content = map[string]interface{}{}
+	}
+
+	// filter system messages (content type == 1)
+	if contentType, ok := content["type"].(float64); ok && contentType == 1 {
+		return nil
+	}
+
+	// ensure channelId in content
+	if _, ok := content["channelId"]; !ok {
+		if chID, ok := raw["channelId"]; ok {
+			content["channelId"] = chID
+		}
+	}
+
+	// build actor
+	var actor *Actor
+	if actorRaw, ok := raw["actor"].(map[string]interface{}); ok {
+		actorType, _ := actorRaw["type"].(string)
+		actor = &Actor{Type: actorType, Data: actorRaw}
+	} else if senderID, ok := content["senderId"].(string); ok {
+		actor = &Actor{
+			Type: "organizationMember",
+			Data: map[string]interface{}{
+				"organizationMember": map[string]interface{}{"id": senderID},
+			},
+		}
+	}
+
+	// map channelLog → message for user handlers
+	eventType := msgType
+	if msgType == "channelLog" {
+		eventType = "message"
+	}
+
+	return &SocketModeRequest{
+		EnvelopeID: stringVal(raw, "envelope_id"),
+		Type:       eventType,
+		Service:    ServiceMessenger,
+		Action:     action,
+		Payload:    content,
+		Entity:     &Entity{Type: "message", Data: content},
+		Actor:      actor,
+	}
+}
+
+func stringVal(m map[string]interface{}, key string) string {
+	v, _ := m[key].(string)
+	return v
+}
+
+func (a *Agent) dispatch(req *SocketModeRequest) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	// service-specific handlers
+	switch req.Service {
+	case ServiceMessenger:
+		if a.messengerHandler != nil {
+			a.messengerHandler(req)
+		}
+	case ServiceTask:
+		if a.taskHandler != nil {
+			a.taskHandler(req)
+		}
+	case ServiceWiki:
+		if a.wikiHandler != nil {
+			a.wikiHandler(req)
+		}
+	}
+
+	// generic filtered handlers
+	for _, h := range a.genericHandlers {
+		if h.service != "" && h.service != req.Service {
+			continue
+		}
+		if h.typ != "" && h.typ != req.Type {
+			continue
+		}
+		if h.action != "" && h.action != req.Action {
+			continue
+		}
+		h.fn(req)
+	}
+}

--- a/socketmode/errors.go
+++ b/socketmode/errors.go
@@ -1,0 +1,10 @@
+package socketmode
+
+import "errors"
+
+var (
+	ErrNoChannel   = errors.New("socketmode: no channel ID available for reply")
+	ErrNoWebClient = errors.New("socketmode: web client not initialized")
+	ErrNoToken     = errors.New("socketmode: agent token is required")
+	ErrNoDomain    = errors.New("socketmode: domain is required (e.g. WithDomain(\"company.dooray.com\"))")
+)

--- a/socketmode/options.go
+++ b/socketmode/options.go
@@ -1,0 +1,65 @@
+package socketmode
+
+import (
+	"log"
+	"net/http"
+	"time"
+)
+
+const (
+	ServiceMessenger = "messenger"
+	ServiceTask      = "task"
+	ServiceWiki      = "wiki"
+
+	defaultBaseURL      = "https://api.dooray.com"
+	defaultPingInterval = 30 * time.Second
+	defaultPingTimeout  = 10 * time.Second
+	defaultReconnectMin = 1 * time.Second
+	defaultReconnectMax = 30 * time.Second
+)
+
+// Option configures the Agent.
+type Option func(*Agent)
+
+// WithBaseURL sets the Dooray API base URL.
+func WithBaseURL(url string) Option {
+	return func(a *Agent) {
+		a.baseURL = url
+	}
+}
+
+// WithDomain sets the Dooray domain (e.g. "company").
+func WithDomain(domain string) Option {
+	return func(a *Agent) {
+		a.domain = domain
+	}
+}
+
+// WithHTTPClient sets a custom HTTP client for REST API calls.
+func WithHTTPClient(client *http.Client) Option {
+	return func(a *Agent) {
+		a.httpClient = client
+	}
+}
+
+// WithLogger sets a custom logger.
+func WithLogger(logger *log.Logger) Option {
+	return func(a *Agent) {
+		a.logger = logger
+	}
+}
+
+// WithPingInterval sets the WebSocket ping interval.
+func WithPingInterval(d time.Duration) Option {
+	return func(a *Agent) {
+		a.pingInterval = d
+	}
+}
+
+// WithReconnectBackoff sets the min and max reconnect backoff durations.
+func WithReconnectBackoff(min, max time.Duration) Option {
+	return func(a *Agent) {
+		a.reconnectMin = min
+		a.reconnectMax = max
+	}
+}

--- a/socketmode/request.go
+++ b/socketmode/request.go
@@ -1,0 +1,114 @@
+package socketmode
+
+import "github.com/dooray-go/dooray/openapi/messenger"
+
+// SocketModeRequest represents an incoming event from the Dooray WebSocket connection.
+type SocketModeRequest struct {
+	EnvelopeID string                 `json:"envelope_id"`
+	Type       string                 `json:"type"`
+	Service    string                 `json:"service"`
+	Action     string                 `json:"action"`
+	Payload    map[string]interface{} `json:"payload"`
+	Entity     *Entity                `json:"entity"`
+	Actor      *Actor                 `json:"actor"`
+	ActionData *DataWrapper           `json:"actionData"`
+
+	// agent is a back-reference used by Reply().
+	agent *Agent
+}
+
+// Entity wraps the event entity data.
+type Entity struct {
+	Type string                 `json:"type"`
+	Data map[string]interface{} `json:"data"`
+}
+
+// Actor wraps information about the user who triggered the event.
+type Actor struct {
+	Type string                 `json:"type"`
+	Data map[string]interface{} `json:"data"`
+}
+
+// DataWrapper wraps additional action detail data.
+type DataWrapper struct {
+	Type string                 `json:"type"`
+	Data map[string]interface{} `json:"data"`
+}
+
+// IsMessage returns true if the event is a messenger message.
+func (r *SocketModeRequest) IsMessage() bool {
+	return r.Service == ServiceMessenger && r.Type == "message"
+}
+
+// Text extracts the message text from the entity data.
+func (r *SocketModeRequest) Text() string {
+	if r.Entity == nil || r.Entity.Data == nil {
+		return ""
+	}
+	if text, ok := r.Entity.Data["text"].(string); ok {
+		return text
+	}
+	return ""
+}
+
+// ChannelID extracts the channel ID from the entity data.
+func (r *SocketModeRequest) ChannelID() string {
+	if r.Entity == nil || r.Entity.Data == nil {
+		return ""
+	}
+	if ch, ok := r.Entity.Data["channelId"].(string); ok {
+		return ch
+	}
+	return ""
+}
+
+// SenderID extracts the sender member ID from the entity data.
+func (r *SocketModeRequest) SenderID() string {
+	if r.Entity == nil || r.Entity.Data == nil {
+		return ""
+	}
+	if id, ok := r.Entity.Data["senderId"].(string); ok {
+		return id
+	}
+	return ""
+}
+
+// IsBotMessage returns true if the message was sent by this bot itself.
+// It compares the sender ID with the bot's own organizationMemberId
+// obtained during socket mode token exchange.
+// Use this to avoid infinite loops when the bot replies to its own messages.
+func (r *SocketModeRequest) IsBotMessage() bool {
+	if r.agent == nil || r.agent.memberID == "" {
+		return false
+	}
+	return r.SenderID() == r.agent.memberID
+}
+
+// IsType checks if the event type matches.
+func (r *SocketModeRequest) IsType(t string) bool {
+	return r.Type == t
+}
+
+// IsAction checks if the event action matches.
+func (r *SocketModeRequest) IsAction(a string) bool {
+	return r.Action == a
+}
+
+// IsService checks if the event service matches.
+func (r *SocketModeRequest) IsService(s string) bool {
+	return r.Service == s
+}
+
+// Reply sends a text message back to the channel where the event originated.
+// Only works for messenger events with a channel ID.
+func (r *SocketModeRequest) Reply(text string) error {
+	ch := r.ChannelID()
+	if ch == "" {
+		return ErrNoChannel
+	}
+	if r.agent == nil || r.agent.messenger == nil {
+		return ErrNoWebClient
+	}
+	_, err := r.agent.messenger.SendMessage(r.agent.agentToken, ch, &messenger.SendMessageRequest{Text: text})
+	return err
+}

--- a/utils/httpclient.go
+++ b/utils/httpclient.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"net"
+	"net/http"
+	"time"
+)
+
+const (
+	DefaultConnectTimeout = 3 * time.Second
+	DefaultReadTimeout    = 10 * time.Second
+)
+
+// NewDefaultHTTPClient creates an *http.Client with sensible default timeouts.
+//   - Connection timeout: 3s
+//   - Total request timeout (read): 10s
+func NewDefaultHTTPClient() *http.Client {
+	return NewHTTPClient(DefaultConnectTimeout, DefaultReadTimeout)
+}
+
+// NewHTTPClient creates an *http.Client with the given connect and read timeouts.
+func NewHTTPClient(connectTimeout, readTimeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout: readTimeout,
+		Transport: &http.Transport{
+			DialContext: (&net.Dialer{
+				Timeout: connectTimeout,
+			}).DialContext,
+			TLSHandshakeTimeout: connectTimeout,
+		},
+	}
+}


### PR DESCRIPTION
- socketmode 패키지 추가: WebSocket 기반 실시간 이벤트 처리
  - POST /common/v1/socket-mode/tokens으로 토큰 발급
  - wss://{domain}/messenger/v5/ws/{tenantId}/{memberId} 연결
  - 자동 재연결 (exponential backoff with jitter)
  - 서비스별 핸들러 (OnMessenger, OnTask, OnWiki) 및 필터링 핸들러 (On)
  - IsBotMessage()로 봇 자신 메시지 필터링 (무한 루프 방지)
- openapi/messenger에 SendMessage 메서드 추가
- 각 클라이언트 구조체 타입 선언을 패키지명.go로 통일 (account, messenger)
- HTTP 클라이언트 기본 타임아웃 설정 (connect: 3s, read: 10s)
  - utils.NewDefaultHTTPClient(), NewHTTPClient() 추가
  - 모든 클라이언트에서 http.DefaultClient 대신 타임아웃 설정된 클라이언트 사용
  - NewXxxWithClient() 생성자로 커스텀 클라이언트 주입 가능