### PR TITLE
fix: ParentInfo.Number 타입을 int로 수정 (서브태스크 포함 응답 unmarshal 실패)

### DIFF
--- a/openapi/model/project/getposts_response.go
+++ b/openapi/model/project/getposts_response.go
@@ -6,7 +6,7 @@ import (
 
 type ParentInfo struct {
 	ID      string `json:"id"`      // 상위 업무 ID
-	Number  string `json:"number"`  // 상위 업무 번호
+	Number  int    `json:"number"`  // 상위 업무 번호
 	Subject string `json:"subject"` // 상위 업무 제목
 }
 

--- a/openapi/project/getposts_test.go
+++ b/openapi/project/getposts_test.go
@@ -30,7 +30,7 @@ var testResponse = `{
        "priority": "",
        "parent": {
            "id": "",
-           "number": "",
+           "number": 0,
            "subject": ""
        },
        "workflowClass": "working",


### PR DESCRIPTION
## 발견 상황

Claude Code에서 dooray-mcp(`dooray_posts` find_posts)로 업무를 조회하던 중, 결과에 서브태스크(상위 업무가 있는 업무)가 한 건이라도 포함되면 호출 전체가 실패하는 문제를 발견했습니다.

```
MCP error -32603: failed to unmarshal response: json: cannot unmarshal number
into Go struct field ParentInfo.result.parent.number of type string
```

실제 Dooray API(`GET /project/v1/projects/{project-id}/posts`)는 `parent.number`를 JSON 숫자로 반환하는데, `ParentInfo.Number`가 `string`으로 선언되어 있어 unmarshal에 실패합니다. 같은 응답 모델의 `PostInfo.Number`는 이미 `int`로 올바르게 선언되어 있습니다.

서브태스크를 사용하는 프로젝트에서는 정렬·필터 조건에 따라 대부분의 업무 조회가 실패하게 됩니다.

## 수정 내용

- `openapi/model/project/getposts_response.go`: `ParentInfo.Number` 타입을 `string` → `int`로 수정
- `openapi/project/getposts_test.go`: 테스트 픽스처의 `"number": ""`를 실제 API 응답 형식에 맞게 `"number": 0`으로 수정

## Test plan

- [x] `go test ./...` 전체 통과
- [x] 실제 Dooray 토큰으로 A/B 검증 — 동일 쿼리(서브태스크 포함 프로젝트, `order=-postUpdatedAt`)를 v0.4.1로 실행 시 위 오류 재현, 본 패치 적용 시 정상 응답(`parent.number` 정상 파싱) 확인
- [x] 패치 SDK로 dooray-mcp를 빌드해 MCP 경유 동일 쿼리 정상 동작 확인

---

이 수정은 [Claude Code](https://claude.com/claude-code)를 사용해 분석·작성되었습니다 (버그 원인 분석, 코드 수정, 실제 API 검증).